### PR TITLE
Mark 1.1.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,10 @@ The API consists of all public Kotlin types from `com.atlassian.performance.tool
 [behavioral compatibility]: http://cr.openjdk.java.net/~darcy/OpenJdkDevGuide/OpenJdkDevelopersGuide.v0.777.html#behavioral_compatibility
 
 ## [Unreleased]
-[Unreleased]: https://github.com/atlassian/jvm-tasks/compare/release-1.0.1...master
+[Unreleased]: https://github.com/atlassian/jvm-tasks/compare/release-1.1.0...master
+
+## [1.1.0] - 2020-08-25
+[1.1.0]: https://github.com/atlassian/jvm-tasks/compare/release-1.0.1...release-1.1.0
 
 ### Added
 - Add static, jitter and sum back-offs.


### PR DESCRIPTION
Artifacts: https://packages.atlassian.com/maven-public/com/atlassian/performance/tools/jvm-tasks/1.1.0/