### PR TITLE
JPERF-767: Bump log4j to 2.17.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,7 +19,7 @@ dependencies {
 fun log4j(
     vararg modules: String
 ): List<String> = modules.map { module ->
-    "org.apache.logging.log4j:log4j-$module:2.10.0"
+    "org.apache.logging.log4j:log4j-$module:2.17.0"
 }
 
 tasks.wrapper {


### PR DESCRIPTION
No dependency locking here.