### PR TITLE
JPERF-1196: Emit events in `TaskTimer`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,10 @@ E.g. you can depend on `[1.3.0, 2.0.0)` and know that `log4j-core` will not come
 
 ### Added
 - Drop major versions of `log4j-core` and `log4j-slf4j-impl`. Fix [JPERF-570].
+- Add `TaskTimer.TaskStartedHandler`, `TaskTimer.TaskSucceededHandler` and `TaskTimer.TaskFailedHandler` interfaces. Unblock [JPERF-1196].
+- Add functions for subscribing and unsubscribing task handlers in `TaskTimer`. Unblock [JPERF-1196].
+
+[JPERF-1196]: https://ecosystem.atlassian.net/browse/JPERF-1196
 
 ### Fixed
 - Relax `log4j-api` dependency to a SemVer range.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
 val kotlinVersion = "1.2.70"
 val log4jVersion = "[2.6, 2.999.999)"
 
@@ -11,6 +13,7 @@ dependencies {
     testCompile("junit:junit:4.12")
     testCompile("org.assertj:assertj-core:3.12.2")
     implementation("org.apache.logging.log4j:log4j-api:$log4jVersion")
+    implementation("net.jcip:jcip-annotations:1.0")
     testImplementation("org.apache.logging.log4j:log4j-core:$log4jVersion")
 }
 

--- a/src/main/kotlin/com/atlassian/performance/tools/jvmtasks/api/TaskTimer.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/jvmtasks/api/TaskTimer.kt
@@ -1,13 +1,19 @@
 package com.atlassian.performance.tools.jvmtasks.api
 
+import net.jcip.annotations.ThreadSafe
 import org.apache.logging.log4j.CloseableThreadContext
 import org.apache.logging.log4j.LogManager
+import org.apache.logging.log4j.ThreadContext
 import java.time.Duration
 import java.time.Instant.now
+import java.util.concurrent.CopyOnWriteArrayList
 
+@ThreadSafe
 object TaskTimer {
-
     private val logger = LogManager.getLogger(this::class.java)
+    private val taskStartedHandlers = CopyOnWriteArrayList<TaskStartedHandler>()
+    private val taskSucceededHandlers = CopyOnWriteArrayList<TaskSucceededHandler>()
+    private val taskFailedHandlers = CopyOnWriteArrayList<TaskFailedHandler>()
 
     /**
      * Logs the duration taken by [task].
@@ -17,12 +23,43 @@ object TaskTimer {
         task: () -> T
     ): T {
         CloseableThreadContext.push(label).use {
+            val path = ThreadContext.cloneStack().asList()
+            taskStartedHandlers.forEach { it.onTaskStarted(path) }
             val start = now()
-            val result = task()
+            val result =
+                try {
+                    task()
+                } catch (e: Exception) {
+                    val duration = Duration.between(start, now())
+                    taskFailedHandlers.forEach { it.onTaskFailed(path, duration, e) }
+                    throw e
+                }
             val duration = Duration.between(start, now())
-
+            taskSucceededHandlers.forEach { it.onTaskSucceeded(path, duration) }
             logger.debug("The task took $duration")
             return result
         }
+    }
+
+    fun subTaskStarted(handler: TaskStartedHandler) {  taskStartedHandlers.add(handler) }
+    fun subTaskSucceeded(handler: TaskSucceededHandler) { taskSucceededHandlers.add(handler) }
+    fun subTaskFailed(handler: TaskFailedHandler) { taskFailedHandlers.add(handler) }
+    fun unsubTaskStarted(handler: TaskStartedHandler) { taskStartedHandlers.remove(handler)}
+    fun unsubTaskSucceeded(handler: TaskSucceededHandler) { taskSucceededHandlers.remove(handler) }
+    fun unsubTaskFailed(handler: TaskFailedHandler) { taskFailedHandlers.remove(handler) }
+
+    @ThreadSafe
+    interface TaskStartedHandler {
+        fun onTaskStarted(path: List<String>)
+    }
+
+    @ThreadSafe
+    interface TaskSucceededHandler {
+        fun onTaskSucceeded(path: List<String>, duration: Duration)
+    }
+
+    @ThreadSafe
+    interface TaskFailedHandler {
+        fun onTaskFailed(path: List<String>, duration: Duration, fail: Throwable)
     }
 }

--- a/src/test/kotlin/com/atlassian/performance/tools/jvmtasks/api/TaskTimerTest.kt
+++ b/src/test/kotlin/com/atlassian/performance/tools/jvmtasks/api/TaskTimerTest.kt
@@ -1,0 +1,61 @@
+package com.atlassian.performance.tools.jvmtasks.api
+
+import com.atlassian.performance.tools.jvmtasks.api.TaskTimer.time
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.catchThrowable
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import java.time.Duration
+
+class TaskTimerTest {
+    private val handler = DummyEventHandler()
+
+    @Before
+    fun setUp() {
+        TaskTimer.subTaskStarted(handler)
+        TaskTimer.subTaskSucceeded(handler)
+        TaskTimer.subTaskFailed(handler)
+    }
+
+    @After
+    fun tearDown() {
+        TaskTimer.unsubTaskStarted(handler)
+        TaskTimer.unsubTaskSucceeded(handler)
+        TaskTimer.unsubTaskFailed(handler)
+    }
+
+    @Test
+    fun shouldReceiveEvent() {
+        time("Success") {
+        }
+
+        assertThat(handler.taskStartedCalls).containsOnly(listOf("Success"))
+        assertThat(handler.taskSucceededCalls).containsOnly(listOf("Success"))
+        assertThat(handler.taskFailedCalls).isEmpty()
+    }
+
+    @Test
+    fun shouldReceiveEventWhenTaskFails() {
+        val exception = catchThrowable {
+            time("Fail") {
+                throw Exception("test exception")
+            }
+        }
+
+        assertThat(exception).isNotNull()
+        assertThat(handler.taskStartedCalls).containsOnly(listOf("Fail"))
+        assertThat(handler.taskFailedCalls).containsOnly(listOf("Fail"))
+        assertThat(handler.taskSucceededCalls).isEmpty()
+    }
+
+    class DummyEventHandler : TaskTimer.TaskStartedHandler, TaskTimer.TaskSucceededHandler, TaskTimer.TaskFailedHandler {
+        val taskStartedCalls = mutableListOf<List<String>>()
+        val taskSucceededCalls = mutableListOf<List<String>>()
+        val taskFailedCalls = mutableListOf<List<String>>()
+
+        override fun onTaskStarted(path: List<String>) { taskStartedCalls.add(path) }
+        override fun onTaskSucceeded(path: List<String>, duration: Duration) { taskSucceededCalls.add(path) }
+        override fun onTaskFailed(path: List<String>, duration: Duration, fail: Throwable) { taskFailedCalls.add(path) }
+    }
+}


### PR DESCRIPTION
Our GUI is using this library. We want to display when the task starts and ends. We could implement it outside of this library. However, we figured out that TaskTimer is already used in a similar context in many places, so we decided to reuse it. We believe EventHandler is generic enough to be used by other use cases.